### PR TITLE
Cache profile infos until they are updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Once you have saved `.env.local` and have restarted the dev server (`pnpm dev`),
 If a request is successful, the app will create or update a corresponding file named `data/profile-infos/[profile-name].yaml`.
 The contents of this file are then used to render profile info on the home page.
 
+Because profile infos rarely change, they are read via [`use cache`](https://nextjs.org/docs/app/api-reference/directives/use-cache) and are kept in memory until an update endpoint rewrites them.
+This means that manual edits to `data/profile-infos/*.yaml` only show up after a server restart.
+
 The list of available profiles can be found in [`app/[locale]/update-profiles/`](app/[locale]/update-profiles/).
 Note that updating Flickr profile requires API authentication, so requests to `/update-profiles/flickr?123` will fail without valid values for `FLICKR_USER_ID` and `FLICKR_API_KEY` inside `.env.local`.
 

--- a/app/[locale]/shared/profile-infos.ts
+++ b/app/[locale]/shared/profile-infos.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { dump, load } from "js-yaml";
+import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 
 import { serverEnv } from "./server-env";
 
@@ -19,9 +20,18 @@ const profileInfosUpdateErrorsDirPath = path.resolve(
   "update-errors",
 );
 
+function generateProfileInfoCacheTag(profileName: string): string {
+  return `profile-info:${profileName}`;
+}
+
 export async function readProfileInfo(
   profileName: string,
 ): Promise<Record<string, unknown> | undefined> {
+  "use cache";
+  // Profile infos only change when writeProfileInfo() is called, which expires the cache tag
+  cacheLife("max");
+  cacheTag(generateProfileInfoCacheTag(profileName));
+
   try {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO: Use zod instead of type assertions
     return load(
@@ -45,6 +55,8 @@ export async function writeProfileInfo(
     dump(profileInfo),
     "utf8",
   );
+
+  revalidateTag(generateProfileInfoCacheTag(profileName), "max");
 }
 
 export function generateUpdateProfileErrorPathPrefix(


### PR DESCRIPTION
This PR follows #898. It reads profile infos via `use cache` with `cacheLife("max")` and a per-profile tag, which `writeProfileInfo()` expires — so the daily cron updates take effect immediately and page renders no longer touch the file system.