### PR TITLE
Replace not-found.tsx with global-not-found.tsx

### DIFF
--- a/app/[locale]/layout/shell.tsx
+++ b/app/[locale]/layout/shell.tsx
@@ -9,7 +9,7 @@ import { ProgressProvider } from "./progress-provider";
 
 /**
  * Wraps page contents into an HTML document.
- * Used by layout.tsx as well as by not-found.tsx, which is outside the [locale] segment.
+ * Used by layout.tsx as well as by global-not-found.tsx, which is outside the [locale] segment.
  */
 export function Shell({ children }: { children: React.ReactNode }) {
   const locale = useLocale();

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -11,7 +11,7 @@ import { Mailto } from "./[locale]/shared/mailto";
  * This route is outside the [locale] segment, so it comes with its own HTML document.
  * The locale is resolved by the request host (see i18n/request.ts).
  */
-export default function NotFound() {
+export default function GlobalNotFound() {
   const t = useTranslations("error");
   const tCommon = useTranslations("common");
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -7,6 +7,14 @@ export default defineConfig([
   }),
 
   {
+    // The shared config allowlists Next.js file conventions, but not this one yet
+    files: ["app/global-not-found.tsx"],
+    rules: {
+      "import/no-default-export": "off",
+    },
+  },
+
+  {
     rules: {
       "import/no-extraneous-dependencies": [
         "warn",

--- a/i18n/locale-by-host.ts
+++ b/i18n/locale-by-host.ts
@@ -15,7 +15,7 @@ const localeByHost: Record<string, Locale | undefined> = Object.fromEntries(
 
 /**
  * Resolves the locale the same way proxy.ts does.
- * Needed in routes that are outside the [locale] segment (e.g. not-found.tsx),
+ * Needed in routes that are outside the [locale] segment (e.g. global-not-found.tsx),
  * because next/root-params is unavailable there.
  */
 export async function getLocaleByHost(): Promise<Locale> {

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -13,7 +13,7 @@ const messagesByLocale = {
 
 // eslint-disable-next-line import/no-default-export -- required by next-intl
 export default getRequestConfig(async ({ locale: explicitLocale }) => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- root params are typed as always defined, but they are unavailable in routes that are outside the [locale] segment, e.g. not-found.tsx
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- root params are typed as always defined, but they are unavailable in routes that are outside the [locale] segment, e.g. global-not-found.tsx
   const localeFromRootParams = (await rootParams.locale()) as
     string | undefined;
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,11 @@ const nextConfig: NextConfig = {
   partialPrefetching: true,
 
   experimental: {
+    // The root layout is inside the [locale] segment, so there is no app/layout.tsx that
+    // app/not-found.tsx could be composed with. Without this flag, Next.js wraps not-found.tsx
+    // into a built-in `<html><body>` layout, which conflicts with the document rendered by Shell.
+    globalNotFound: true,
+
     // `typescript` resolves to `@typescript/typescript6`, which ships no `tsc`
     // binary, so Next.js has to use the TypeScript API instead of the CLI
     useTypeScriptCli: false,


### PR DESCRIPTION
This PR fixes a hydration mismatch on every unmatched pathname. Because the root layout lives inside the [locale] segment, Next.js wrapped not-found.tsx in a built-in `<html><body>` layout, nesting it around the document rendered by Shell — the browser merged the inner tags' attributes into the outer ones, so `lang` and the body className were in the DOM but not in what React rendered on the client.

`experimental.globalNotFound` stops that layout from being injected. Note that global-not-found.tsx only covers unmatched URLs, not `notFound()` thrown inside a segment; the only such call is in i18n/request.ts and is unreachable while proxy.ts constrains the locale.